### PR TITLE
Add tasks page and sidebar navigation

### DIFF
--- a/app/archive/page.tsx
+++ b/app/archive/page.tsx
@@ -1,0 +1,10 @@
+import { MailLayout } from "@/components/mail-layout"
+import { AuthGuard } from "@/components/auth/auth-guard"
+
+export default function ArchivePage() {
+  return (
+    <AuthGuard>
+      <MailLayout />
+    </AuthGuard>
+  )
+}

--- a/app/contacts/page.tsx
+++ b/app/contacts/page.tsx
@@ -1,0 +1,12 @@
+import { AuthGuard } from "@/components/auth/auth-guard"
+
+export default function ContactsPage() {
+  return (
+    <AuthGuard>
+      <div className="p-6">
+        <h1 className="text-2xl font-semibold">Contacts</h1>
+        <p className="mt-2 text-muted-foreground">Manage your contacts here.</p>
+      </div>
+    </AuthGuard>
+  )
+}

--- a/app/inbox/page.tsx
+++ b/app/inbox/page.tsx
@@ -1,0 +1,10 @@
+import { MailLayout } from "@/components/mail-layout"
+import { AuthGuard } from "@/components/auth/auth-guard"
+
+export default function InboxPage() {
+  return (
+    <AuthGuard>
+      <MailLayout />
+    </AuthGuard>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,5 @@
-import { MailLayout } from "@/components/mail-layout"
-import { AuthGuard } from "@/components/auth/auth-guard"
+import { redirect } from "next/navigation"
 
 export default function HomePage() {
-  return (
-    <AuthGuard>
-      <MailLayout />
-    </AuthGuard>
-  )
+  redirect("/inbox")
 }

--- a/app/sent/page.tsx
+++ b/app/sent/page.tsx
@@ -1,0 +1,10 @@
+import { MailLayout } from "@/components/mail-layout"
+import { AuthGuard } from "@/components/auth/auth-guard"
+
+export default function SentPage() {
+  return (
+    <AuthGuard>
+      <MailLayout />
+    </AuthGuard>
+  )
+}

--- a/app/starred/page.tsx
+++ b/app/starred/page.tsx
@@ -1,0 +1,10 @@
+import { MailLayout } from "@/components/mail-layout"
+import { AuthGuard } from "@/components/auth/auth-guard"
+
+export default function StarredPage() {
+  return (
+    <AuthGuard>
+      <MailLayout />
+    </AuthGuard>
+  )
+}

--- a/app/tasks/page.tsx
+++ b/app/tasks/page.tsx
@@ -1,0 +1,10 @@
+import { TaskList } from "@/components/task-list"
+import { AuthGuard } from "@/components/auth/auth-guard"
+
+export default function TasksPage() {
+  return (
+    <AuthGuard>
+      <TaskList />
+    </AuthGuard>
+  )
+}

--- a/app/trash/page.tsx
+++ b/app/trash/page.tsx
@@ -1,0 +1,10 @@
+import { MailLayout } from "@/components/mail-layout"
+import { AuthGuard } from "@/components/auth/auth-guard"
+
+export default function TrashPage() {
+  return (
+    <AuthGuard>
+      <MailLayout />
+    </AuthGuard>
+  )
+}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -26,18 +26,18 @@ import {
 } from "lucide-react"
 import Link from "next/link"
 import { useAuth } from "@/contexts/auth-context"
-import { useRouter } from "next/navigation"
+import { useRouter, usePathname } from "next/navigation"
 
 interface SidebarProps {
   collapsed: boolean
 }
 
 const navigationItems = [
-  { icon: Mail, label: "Inbox", count: 12, active: false },
-  { icon: Star, label: "Starred", count: 3 },
-  { icon: Send, label: "Sent" },
-  { icon: Archive, label: "Archive" },
-  { icon: Trash2, label: "Trash", count: 2 },
+  { icon: Mail, label: "Inbox", count: 12, href: "/inbox" },
+  { icon: Star, label: "Starred", count: 3, href: "/starred" },
+  { icon: Send, label: "Sent", href: "/sent" },
+  { icon: Archive, label: "Archive", href: "/archive" },
+  { icon: Trash2, label: "Trash", count: 2, href: "/trash" },
 ]
 
 const modules = [
@@ -52,6 +52,7 @@ const modules = [
 export function Sidebar({ collapsed }: SidebarProps) {
   const { user, logout } = useAuth()
   const router = useRouter()
+  const pathname = usePathname()
 
   const handleLogout = () => {
     logout()
@@ -89,29 +90,35 @@ export function Sidebar({ collapsed }: SidebarProps) {
         <div className="p-2">
           {/* Mail Navigation */}
           <div className="space-y-1">
-            {navigationItems.map((item) => (
-              <Button
-                key={item.label}
-                variant={item.active ? "default" : "ghost"}
-                className={cn(
-                  "w-full justify-start",
-                  collapsed ? "px-2" : "px-3",
-                  item.active && "bg-sidebar-primary text-sidebar-primary-foreground",
-                )}
-              >
-                <item.icon className="w-4 h-4" />
-                {!collapsed && (
-                  <>
-                    <span className="ml-3 flex-1 text-left">{item.label}</span>
-                    {item.count && (
-                      <span className="ml-auto text-xs bg-sidebar-accent text-sidebar-accent-foreground px-2 py-1 rounded-full">
-                        {item.count}
-                      </span>
+            {navigationItems.map((item) => {
+              const isActive = pathname === item.href
+              return (
+                <Button
+                  key={item.label}
+                  asChild
+                  variant={isActive ? "default" : "ghost"}
+                  className={cn(
+                    "w-full justify-start",
+                    collapsed ? "px-2" : "px-3",
+                    isActive && "bg-sidebar-primary text-sidebar-primary-foreground",
+                  )}
+                >
+                  <Link href={item.href} className="flex items-center w-full">
+                    <item.icon className="w-4 h-4" />
+                    {!collapsed && (
+                      <>
+                        <span className="ml-3 flex-1 text-left">{item.label}</span>
+                        {item.count && (
+                          <span className="ml-auto text-xs bg-sidebar-accent text-sidebar-accent-foreground px-2 py-1 rounded-full">
+                            {item.count}
+                          </span>
+                        )}
+                      </>
                     )}
-                  </>
-                )}
-              </Button>
-            ))}
+                  </Link>
+                </Button>
+              )
+            })}
           </div>
 
           {/* Modules */}

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -24,6 +24,7 @@ import {
   User,
   LogOut,
 } from "lucide-react"
+import Link from "next/link"
 import { useAuth } from "@/contexts/auth-context"
 import { useRouter } from "next/navigation"
 
@@ -40,12 +41,12 @@ const navigationItems = [
 ]
 
 const modules = [
-  { icon: Calendar, label: "Calendar" },
-  { icon: Files, label: "Files", active: true }, // Set Files as active module
-  { icon: CheckSquare, label: "Tasks" },
-  { icon: Users, label: "Contacts" },
-  { icon: Search, label: "Search", active: true }, // Added Search module as active
-  { icon: Settings, label: "Admin", href: "/admin" }, // Added Admin module for system administration
+  { icon: Calendar, label: "Calendar", href: "/calendar" },
+  { icon: Files, label: "Files", href: "/files" },
+  { icon: CheckSquare, label: "Tasks", href: "/tasks" },
+  { icon: Users, label: "Contacts", href: "/contacts" },
+  { icon: Search, label: "Search", href: "/search" },
+  { icon: Settings, label: "Admin", href: "/admin" },
 ]
 
 export function Sidebar({ collapsed }: SidebarProps) {
@@ -121,17 +122,11 @@ export function Sidebar({ collapsed }: SidebarProps) {
               </h3>
               <div className="space-y-1">
                 {modules.map((item) => (
-                  <Button
-                    key={item.label}
-                    variant={item.active ? "default" : "ghost"}
-                    className={cn(
-                      "w-full justify-start px-3",
-                      item.active && "bg-sidebar-primary text-sidebar-primary-foreground",
-                    )}
-                    onClick={() => item.href && router.push(item.href)}
-                  >
-                    <item.icon className="w-4 h-4" />
-                    <span className="ml-3">{item.label}</span>
+                  <Button key={item.label} variant="ghost" className="w-full justify-start px-3" asChild>
+                    <Link href={item.href} className="flex items-center w-full">
+                      <item.icon className="w-4 h-4" />
+                      <span className="ml-3">{item.label}</span>
+                    </Link>
                   </Button>
                 ))}
               </div>


### PR DESCRIPTION
## Summary
- Add Tasks page that displays the TaskList component under AuthGuard
- Link Tasks module in the sidebar to the new Tasks page
- Convert sidebar modules to Next.js links and add Contacts page under AuthGuard

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b46ce1f788832e90b6369f5e655010